### PR TITLE
Add view name option to create_view

### DIFF
--- a/lib/bq_factory.rb
+++ b/lib/bq_factory.rb
@@ -23,9 +23,10 @@ module BqFactory
       configuration
     end
 
-    def create_view(dataset_name, factory_name, rows)
+    def create_view(dataset_name, factory_name, rows, view_name = nil)
+      view_name ||= factory_name
       query = build_query(factory_name, rows)
-      client.create_view(dataset_name, factory_name, query)
+      client.create_view(dataset_name, view_name, query)
     end
 
     def build_query(register_name, rows)

--- a/spec/bq_factory_spec.rb
+++ b/spec/bq_factory_spec.rb
@@ -22,18 +22,33 @@ describe BqFactory do
   end
 
   describe '.create_view' do
-    subject { described_class.create_view(dataset_name, table_id, rows) }
+    subject { described_class.create_view(dataset_name, table_id, rows, view_name) }
     let(:dataset_name) { :dummy_dataset }
     let(:table_id) { :dummy_table }
     let(:rows)     { { name: 'foo' } }
     let(:client)   { double('Client') }
     let(:query)    { %{SELECT * FROM (SELECT "foo" AS name)} }
 
-    it 'should be delegated to client' do
-      expect(described_class).to receive(:build_query).with(table_id, rows).and_return(query)
-      expect(described_class).to receive(:client).and_return(client)
-      expect(client).to receive(:create_view).with(dataset_name, table_id, query)
-      subject
+    context 'when view_name is nil' do
+      let(:view_name) { nil }
+
+      it 'should be delegated to client with table_id' do
+        expect(described_class).to receive(:build_query).with(table_id, rows).and_return(query)
+        expect(described_class).to receive(:client).and_return(client)
+        expect(client).to receive(:create_view).with(dataset_name, table_id, query)
+        subject
+      end
+    end
+
+    context 'when view_name is given' do
+      let(:view_name) { 'dummy_view' }
+      
+      it 'should be delegated to client with given view_name' do
+        expect(described_class).to receive(:build_query).with(table_id, rows).and_return(query)
+        expect(described_class).to receive(:client).and_return(client)
+        expect(client).to receive(:create_view).with(dataset_name, view_name, query)
+        subject
+      end
     end
   end
 


### PR DESCRIPTION
`create_view` method can only make view with table_id registed by `register` method.
But I think it's useful to be able to use another view name, especially daily table like `user20160313`
